### PR TITLE
INT-695 - Disable component file names rule for nuxt pages

### DIFF
--- a/packages/eslint-config/rules/netsells/component-file-names/files.js
+++ b/packages/eslint-config/rules/netsells/component-file-names/files.js
@@ -1,4 +1,7 @@
 module.exports = {
-    correct: 'FooBar.vue',
+    correct: [
+        'FooBar.vue',
+        'resources/pages/foo-bar.vue',
+    ],
     incorrect: 'foo-bar.vue',
 };

--- a/packages/eslint-config/rules/netsells/component-file-names/resources/pages/foo-bar.vue
+++ b/packages/eslint-config/rules/netsells/component-file-names/resources/pages/foo-bar.vue
@@ -1,0 +1,10 @@
+<template>
+    <div>
+    </div>
+</template>
+
+<script>
+    export default {
+        name: 'foo-bar',
+    };
+</script>

--- a/packages/eslint-config/rules/netsells/component-file-names/rule.js
+++ b/packages/eslint-config/rules/netsells/component-file-names/rule.js
@@ -4,4 +4,13 @@ module.exports = {
     rules: {
         '@netsells/netsells/component-file-names': _THROW.WARNING,
     },
+
+    overrides: [
+        {
+            files: ['resources/pages/*.vue'],
+            rules: {
+                '@netsells/netsells/component-file-names': 'off',
+            },
+        },
+    ],
 };


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2FINT-695)](https://netsells.atlassian.net/browse/INT-695)

- Refactor tests so we can have multiple correct/incorrect files
- Add test for nuxt pages
- Add override so this test now passes

```
  netsells/component-file-names
    ✓ FooBar.vue should pass (15ms)
    ✓ resources/pages/foo-bar.vue should pass (7ms)
    ✓ foo-bar.vue should fail (11ms)
```