### PR TITLE
INT-695 - Add layouts exception

### DIFF
--- a/packages/eslint-config/rules/netsells/component-file-names/files.js
+++ b/packages/eslint-config/rules/netsells/component-file-names/files.js
@@ -2,6 +2,7 @@ module.exports = {
     correct: [
         'FooBar.vue',
         'resources/pages/foo-bar.vue',
+        'resources/layouts/foo-bar.vue',
     ],
     incorrect: 'foo-bar.vue',
 };

--- a/packages/eslint-config/rules/netsells/component-file-names/resources/layouts/foo-bar.vue
+++ b/packages/eslint-config/rules/netsells/component-file-names/resources/layouts/foo-bar.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+        <nuxt />
+    </div>
+</template>
+
+<script>
+    export default {
+        name: 'foo-bar',
+    };
+</script>

--- a/packages/eslint-config/rules/netsells/component-file-names/rule.js
+++ b/packages/eslint-config/rules/netsells/component-file-names/rule.js
@@ -7,7 +7,7 @@ module.exports = {
 
     overrides: [
         {
-            files: ['resources/pages/*.vue'],
+            files: ['resources/{pages,layouts}/*.vue'],
             rules: {
                 '@netsells/netsells/component-file-names': 'off',
             },


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2FINT-695)](https://netsells.atlassian.net/browse/INT-695)

Adds exception to the `@netsells/netsells/component-file-names` rule for nuxt layouts