### PR TITLE
Adds require JSDoc ignore rules

### DIFF
--- a/packages/eslint-config/rules/require-jsdoc-except/require-jsdoc/rule.js
+++ b/packages/eslint-config/rules/require-jsdoc-except/require-jsdoc/rule.js
@@ -22,8 +22,16 @@ module.exports = {
                 'updated',
                 'data',
 
+                // Nuxt methods
+                'asyncData',
+                'beforeRouteLeave',
+                'head',
+
                 // Ignore the vue default prop method
                 'default',
+                'get',
+                'set',
+                'handler',
             ],
         }],
     },


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas

### Problem statement
Some of the ignore rules for JSDocs that we add into every project were missing from the global linter rules so we were getting linter errors for example on computed get / set properties when we normally ignore these

### Solution
Added the missing rules so they can be pulled into each project by default

### Dependencies
N/A

### Test procedures
N/A

## Deployment

### Migrations
No

### Environment variables
N/A

### Deployment notes
N/A