### PR TITLE
Bring PR information inline with confluence

### DIFF
--- a/src/general/pull-requests.md
+++ b/src/general/pull-requests.md
@@ -3,6 +3,12 @@
 ## Overview
 This document details what is expected of you and what you can expect during the PR review process. This guide is not definitive or exhaustive but it does cover many of the common obstacles that we all come across. Remember that the intention of a review is to ensure the code quality is as high as possible and discussion is always welcome.
 
+We run all of our code through pull requests for a variety of reasons, these include:
+
+- Sanity checking of logic
+- Code style checks
+- Mentoring opportunities
+
 ## Making a Pull Request
 When creating a pull request, there are a few things to watch out for. Firstly, ensure the base branch is set correctly. The majority of our repos have a master and develop branch and in this case, your work should be merged into develop unless it’s a release from develop to master.
 
@@ -19,11 +25,32 @@ The majority of projects have automated test suites and linters which are run by
 To request a review, select the people that you want from the dropdown panel. You should add a reviewer for each discipline that your PR changes, for example if you build a tool for Nova admin panel you will need both a frontend and backend reviewer. For large or complicated changes, several reviewers are recommended to ensure multiple sets of eyes see them. You should aim to bring in a more senior developer to review your code and junior developers can be added if you believe reviewing the code would be of benefit to them.
 
 ## Review Comments
-When leaving a review, we use the **MUST** and **SHOULD** keywords to indicate the level of a comment. If a reviewer leaves a **MUST** comment, the pull request will be rejected pending changes. It is up to the reviewers discretion to decide whether a PR is rejected due to **SHOULD** comments. Comments can also be left without this syntax which could be a general question asking you for more information or a piece of information that you may not know. 
+When leaving a review, we have two types of pull request comments, **MUST** and **SHOULD**, these keywords to indicate the level of a comment. If a reviewer leaves a **MUST** comment, the pull request will be rejected pending changes. It is up to the reviewers discretion to decide whether a PR is rejected due to **SHOULD** comments. Comments can also be left without this syntax which could be a general question asking you for more information or a piece of information that you may not know. 
 
 Comments should be critical, informative and descriptive enough for you to implement the suggestion. Comments such as “this is wrong” or “this doesn’t work” are not acceptable and should be replaced with an explanation of the problem and suggestions for the solution, including code snippets where appropriate.
 
-Once you have made the requested changes, you can re-request a review from a user. The person who left the original comment will mark the comment as resolved if they are happy with the solution.
+
+
+
+Examples of appropriate comments;
+
+`MUST: It looks like you've missed an import for the DB facade, make sure you prefix with a \ to avoid exceptions!`
+
+```
+SHOULD: we typically split arrays onto multiple lines for better gif diffs (with a trailing comma)
+
+'user' => [
+    'first_name', 
+    'last_name',
+],
+```
+
+## Comment Tips and Examples for Reviewers
+- Try to give clear instructions on what you want changing and do not refer to in-person discussions. Pull requests are often looked back on to understand why decisions were made, "as we spoke about on Tuesday" does not help anyone 5 months later!
+- If an in-person discussion is needed (ie it'll be a lengthy comment thread) - make sure you post back with the summary so it's known to others
+- Provide clear examples whenever possible to help mentor and avoid too many back and forth with clarifications.
+- Read every line of code
+- Don't hold author hostage - We have enough power to block a PR, lets not use this for evil by requesting changes outside the scope of the PR. e.g fixing old code
 
 ## Back to QA?
 Depending on the size and scope of the changes requested to your PR it may be necessary to send the code back through QA. If you’re unsure whether the changes need to go back through QA, your reviewer will be able to give you guidance.

--- a/src/general/pull-requests.md
+++ b/src/general/pull-requests.md
@@ -25,12 +25,9 @@ The majority of projects have automated test suites and linters which are run by
 To request a review, select the people that you want from the dropdown panel. You should add a reviewer for each discipline that your PR changes, for example if you build a tool for Nova admin panel you will need both a frontend and backend reviewer. For large or complicated changes, several reviewers are recommended to ensure multiple sets of eyes see them. You should aim to bring in a more senior developer to review your code and junior developers can be added if you believe reviewing the code would be of benefit to them.
 
 ## Review Comments
-When leaving a review, we have two types of pull request comments, **MUST** and **SHOULD**, these keywords to indicate the level of a comment. If a reviewer leaves a **MUST** comment, the pull request will be rejected pending changes. It is up to the reviewers discretion to decide whether a PR is rejected due to **SHOULD** comments. Comments can also be left without this syntax which could be a general question asking you for more information or a piece of information that you may not know. 
+When leaving a review, we use two types of pull request comments, **MUST** and **SHOULD**, these keywords will indicate the requirement level of a comment. If a reviewer leaves a **MUST** comment, the pull request will be rejected pending changes. It is up to the reviewers discretion to decide whether a PR is rejected due to **SHOULD** comments. Comments can also be left without this syntax which could be a general question asking you for more information or a piece of information that you may not know. 
 
 Comments should be critical, informative and descriptive enough for you to implement the suggestion. Comments such as “this is wrong” or “this doesn’t work” are not acceptable and should be replaced with an explanation of the problem and suggestions for the solution, including code snippets where appropriate.
-
-
-
 
 Examples of appropriate comments;
 

--- a/src/general/pull-requests.md
+++ b/src/general/pull-requests.md
@@ -25,7 +25,7 @@ The majority of projects have automated test suites and linters which are run by
 To request a review, select the people that you want from the dropdown panel. You should add a reviewer for each discipline that your PR changes, for example if you build a tool for Nova admin panel you will need both a frontend and backend reviewer. For large or complicated changes, several reviewers are recommended to ensure multiple sets of eyes see them. You should aim to bring in a more senior developer to review your code and junior developers can be added if you believe reviewing the code would be of benefit to them.
 
 ## Review Comments
-When leaving a review, we use two types of pull request comments, **MUST** and **SHOULD**, these keywords will indicate the requirement level of a comment. If a reviewer leaves a **MUST** comment, the pull request will be rejected pending changes. It is up to the reviewers discretion to decide whether a PR is rejected due to **SHOULD** comments. Comments can also be left without this syntax which could be a general question asking you for more information or a piece of information that you may not know. 
+When leaving a review, we use two types of pull request comments; **MUST** and **SHOULD**. These keywords will indicate the requirement level of a comment. If a reviewer leaves a **MUST** comment, the pull request will be rejected pending changes. It is up to the reviewers discretion to decide whether a PR is rejected due to **SHOULD** comments. Comments can also be left without this syntax which could be a general question asking you for more information or a piece of information that you may not know. 
 
 Comments should be critical, informative and descriptive enough for you to implement the suggestion. Comments such as “this is wrong” or “this doesn’t work” are not acceptable and should be replaced with an explanation of the problem and suggestions for the solution, including code snippets where appropriate.
 
@@ -45,9 +45,10 @@ SHOULD: we typically split arrays onto multiple lines for better gif diffs (with
 ## Comment Tips and Examples for Reviewers
 - Try to give clear instructions on what you want changing and do not refer to in-person discussions. Pull requests are often looked back on to understand why decisions were made, "as we spoke about on Tuesday" does not help anyone 5 months later!
 - If an in-person discussion is needed (ie it'll be a lengthy comment thread) - make sure you post back with the summary so it's known to others
-- Provide clear examples whenever possible to help mentor and avoid too many back and forth with clarifications.
+- Provide clear examples whenever possible to help mentor and avoid excessive back and forth with clarifications.
 - Read every line of code
 - Don't hold author hostage - We have enough power to block a PR, lets not use this for evil by requesting changes outside the scope of the PR. e.g fixing old code
+- Add links to comments where appropriate. External docs and discussions around topics are extremely valuable learning resources.
 
 ## Back to QA?
 Depending on the size and scope of the changes requested to your PR it may be necessary to send the code back through QA. If you’re unsure whether the changes need to go back through QA, your reviewer will be able to give you guidance.

--- a/src/general/pull-requests.md
+++ b/src/general/pull-requests.md
@@ -3,7 +3,7 @@
 ## Overview
 This document details what is expected of you and what you can expect during the PR review process. This guide is not definitive or exhaustive but it does cover many of the common obstacles that we all come across. Remember that the intention of a review is to ensure the code quality is as high as possible and discussion is always welcome.
 
-We run all of our code through pull requests for a variety of reasons, these include:
+We run all of our code through pull requests for a variety of reasons. These include:
 
 - Sanity checking of logic
 - Code style checks
@@ -25,7 +25,7 @@ The majority of projects have automated test suites and linters which are run by
 To request a review, select the people that you want from the dropdown panel. You should add a reviewer for each discipline that your PR changes, for example if you build a tool for Nova admin panel you will need both a frontend and backend reviewer. For large or complicated changes, several reviewers are recommended to ensure multiple sets of eyes see them. You should aim to bring in a more senior developer to review your code and junior developers can be added if you believe reviewing the code would be of benefit to them.
 
 ## Review Comments
-When leaving a review, we use two types of pull request comments; **MUST** and **SHOULD**. These keywords will indicate the requirement level of a comment. If a reviewer leaves a **MUST** comment, the pull request will be rejected pending changes. It is up to the reviewers discretion to decide whether a PR is rejected due to **SHOULD** comments. Comments can also be left without this syntax which could be a general question asking you for more information or a piece of information that you may not know. 
+When leaving a review, we use two types of pull request comments: **MUST** and **SHOULD**. These keywords will indicate the requirement level of a comment. If a reviewer leaves a **MUST** comment, the pull request will be rejected pending changes. It is up to the reviewers discretion to decide whether a PR is rejected due to **SHOULD** comments. Comments can also be left without this syntax which could be a general question asking you for more information or a piece of information that you may not know. 
 
 Comments should be critical, informative and descriptive enough for you to implement the suggestion. Comments such as “this is wrong” or “this doesn’t work” are not acceptable and should be replaced with an explanation of the problem and suggestions for the solution, including code snippets where appropriate.
 
@@ -43,7 +43,7 @@ SHOULD: we typically split arrays onto multiple lines for better gif diffs (with
 ```
 
 ## Comment Tips and Examples for Reviewers
-- Try to give clear instructions on what you want changing and do not refer to in-person discussions. Pull requests are often looked back on to understand why decisions were made, "as we spoke about on Tuesday" does not help anyone 5 months later!
+- Try to give clear instructions on what you want changing and do not refer to in-person discussions. Pull requests are often looked back on to understand why decisions were made; "as we spoke about on Tuesday" does not help anyone 5 months later!
 - If an in-person discussion is needed (ie it'll be a lengthy comment thread) - make sure you post back with the summary so it's known to others
 - Provide clear examples whenever possible to help mentor and avoid excessive back and forth with clarifications.
 - Read every line of code


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient logging
- [x] New and existing tests pass locally with my changes
- [x] The code modified as part of this PR has been covered with tests

### Description
As discussed there were some discrepancies between the pull request information on code standards and confluence so I've tried to bring them inline and match. 

### Dependencies
N/A

### Test procedures
N/A

### Links

Confluence: https://netsells.atlassian.net/wiki/spaces/NO/pages/938442753/Pull+Request+Strategy
